### PR TITLE
add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+CC=clang
+
+CFLAGS := -std=gnu99 -fno-stack-protector -fshort-enums -fpack-struct=1
+LDFLAGS := -lm
+
+SOURCES := $(wildcard src/*.c src/*/*.c)
+HEADERS := $(wildcard src/*.h src/*/*.h)
+OBJECTS := $(subst .c,.o, $(subst src,build, $(SOURCES)))
+
+.Phony: clean
+
+default: ff
+
+ff: $(OBJECTS)
+	$(CC) -o $@ $(OBJECTS) $(LDFLAGS)
+
+$(OBJECTS): ./build/%.o: ./src/%.c
+	mkdir -p $(@D)
+	$(CC) -MMD -MP -c $< -o $@ $(CFLAGS)
+
+clean:
+	rm -f ff
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ SOURCES := $(wildcard src/*.c src/*/*.c)
 HEADERS := $(wildcard src/*.h src/*/*.h)
 OBJECTS := $(subst .c,.o, $(subst src,build, $(SOURCES)))
 
-.Phony: clean
+PREFIX=/usr/local
+
+.Phony: clean install uninstall
 
 default: ff
 
@@ -21,3 +23,11 @@ $(OBJECTS): ./build/%.o: ./src/%.c
 clean:
 	rm -f ff
 	rm -rf build
+
+install: ff
+	cp ff $(PREFIX)/bin
+	cp ./docs/ff.1 $(PREFIX)/share/man/man1
+
+uninstall: 
+	rm -fv $(PREFIX)/bin/ff
+	rm -fv $(PREFIX)/share/man/man1/ff.1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For a list of files ff(1) picks up, visit
 
 # Compiling
 
-There is currently no Makefile at the moment.
+There is a Makefile defaulting to clang. It will work with gcc aswell: `make CC=gcc`.
 
 It's usually best to use `build-clang.cmd` on Windows and `build-clang.sh` on
 Linux, as you can add additional arguments easily. Reminder that you should add

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ For a list of files ff(1) picks up, visit
 
 There is a Makefile defaulting to clang. It will work with gcc aswell: `make CC=gcc`.
 
-It's usually best to use `build-clang.cmd` on Windows and `build-clang.sh` on
-Linux, as you can add additional arguments easily. Reminder that you should add
-`-O3` (or `/Ot` for cl).
+It's usually best to use `build-clang.cmd` on Windows, as you can add additional arguments easily. 
+Reminder that you should add `-O3` (or `/Ot` for cl).
+There is also `build-clang.sh` for Unix-like systems, should you wish not to use the Makefile.
 
 However, if you want to define your own arguments:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There is a Makefile defaulting to clang. It will work with gcc aswell: `make CC=
 
 It's usually best to use `build-clang.cmd` on Windows, as you can add additional arguments easily. 
 Reminder that you should add `-O3` (or `/Ot` for cl).
-There is also `build-clang.sh` for Unix-like systems, should you wish not to use the Makefile.
+There is also `build-clang.sh` as an alternative to the Makefile for Unix-like systems.
 
 However, if you want to define your own arguments:
 


### PR DESCRIPTION
I am a bit unsure on how you'd even run it under windows, how did you run/install clang even?

For that reason you might want to keep the build scripts?

Either way this thing works and you can easily pass in GCC even:
```bash
make CC=gcc
```
